### PR TITLE
Bump to JMS v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"php": "~7.2",
 		"consistence/consistence": "~1.0|~2.0",
-		"jms/serializer": "~2.0"
+		"jms/serializer": "~2.0 || ~3.0"
 	},
 	"require-dev": {
 		"ext-simplexml": "*",


### PR DESCRIPTION
There was some issue with comments in https://github.com/consistence/consistence-jms-serializer/pull/14 so I opened this one.

Discussion followup:
@enumag https://gist.github.com/simPod/b21cdd57c4873a2dadc4013c747a2fc9 it's WIP and multienum support is removed (I currently don't serialise any). Feel free to add comments if you change something.